### PR TITLE
Removing domain on liability_account

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -13,7 +13,6 @@ class Configuration(ModelSingleton, ModelSQL, ModelView):
     liability_account = fields.Property(
         fields.Many2One(
             'account.account', 'Liability Account', required=True,
-            domain=[('kind', '=', 'revenue')]
         )
     )
 


### PR DESCRIPTION
As e.g. in Germany money received for a gift card (not targeted at a special product) isn't considered to be a revenue, but just an exchange of money, the domain on the liability account is too strict. In Germany it would have to be of kind 'others', but other countries could require different behavior. So I propose to remove the domain from the account.